### PR TITLE
Normative: Renaming to ShadowRealm

### DIFF
--- a/DISCUSSIONS.md
+++ b/DISCUSSIONS.md
@@ -4,11 +4,11 @@
 
 Notes about why we need realms:
 
-* Realms allow virtualization of the language itself.
+* ShadowRealms allow virtualization of the language itself.
 * Same origin is seen as legacy from some implementers, but same origin iframes is available anyways.
   * It is also available in node via `vm` module.
 * Same origin is an atomic part of the web reality.
-* Varios examples of why Realms are needed:
+* Varios examples of why ShadowRealms are needed:
   * Web-based IDEs or any kind of 3rd party code execution uses same origin evaluation.
   * Fiddler & Co.
   * JSPerf & Co.

--- a/DISCUSSIONS.md
+++ b/DISCUSSIONS.md
@@ -8,7 +8,7 @@ Notes about why we need realms:
 * Same origin is seen as legacy from some implementers, but same origin iframes is available anyways.
   * It is also available in node via `vm` module.
 * Same origin is an atomic part of the web reality.
-* Varios examples of why ShadowRealms are needed:
+* Various examples of why ShadowRealms are needed:
   * Web-based IDEs or any kind of 3rd party code execution uses same origin evaluation.
   * Fiddler & Co.
   * JSPerf & Co.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# ECMAScript spec proposal for Realms API
+# ECMAScript spec proposal for ShadowRealm API
 
 ## <a name='Status'></a>Status
 
 - [Explainer](explainer.md).
-- [HTML Rendered Spec](https://tc39.es/proposal-realms/).
+- [HTML Rendered Spec](https://tc39.es/proposal-shadowrealm/).
 - Currently at [Stage 3](https://tc39.es/process-document/).
 - [Code of Conduct](https://tc39.es/code-of-conduct/)
 
@@ -16,23 +16,23 @@
 
 ## Index
 
-* [What are Realms?](#WhatareRealms)
+* [What are ShadowRealms?](#WhatareRealms)
 * [API (TypeScript Format)](#APITypeScriptFormat)
 * [Presentations](#Presentations)
 * [History](#History)
 * [Contributing](#Contributing)
 	* [Updating the spec text for this proposal](#Updatingthespectextforthisproposal)
 
-## <a name='WhatareRealms'></a>What are Realms?
+## <a name='WhatareRealms'></a>What are ShadowRealms?
 
-Realms are a distinct global environment, with its own global object containing its own intrinsics and built-ins (standard objects that are not bound to global variables, like the initial value of Object.prototype).
+ShadowRealms are a distinct global environment, with its own global object containing its own intrinsics and built-ins (standard objects that are not bound to global variables, like the initial value of Object.prototype).
 
 See more at the [explainer](explainer.md) document.
 
 ## <a name='APITypeScriptFormat'></a>API (TypeScript Format)
 
 ```ts
-declare class Realm {
+declare class ShadowRealm {
     constructor();
     importValue(specifier: string, bindingName: string): Promise<PrimitiveValueOrCallable>;
     evaluate(sourceText: string): PrimitiveValueOrCallable;
@@ -56,7 +56,7 @@ See some examples [in the Explainer file](explainer.md).
 ## <a name='History'></a>History
 
 * we moved on from the exposed globalThis model to a lean isolated realms API (see #289 and #291)
-* we worked on this during ES2015 time frame, so never went through stages process ([ES6 Realm Objects proto-spec.pdf](https://github.com/tc39/proposal-realms/files/717415/ES6.Realm.Objects.proto-spec.pdf))
+* we worked on this during ES2015 time frame, so never went through stages process ([ES6 Realm Objects proto-spec.pdf](https://github.com/tc39/proposal-shadowrealm/files/717415/ES6.Realm.Objects.proto-spec.pdf))
 * got punted to later (rightly so!)
 * goal of this proposal: resume work on this, reassert committee interest via advancing to stage 2
 * original idea from @dherman: [What are Realms?](https://gist.github.com/dherman/7568885)

--- a/explainer.md
+++ b/explainer.md
@@ -1,4 +1,4 @@
-# Realms Explainer
+# ShadowRealms Explainer
 
 <!-- vscode-markdown-toc -->
 * [Introduction](#Introduction)
@@ -9,8 +9,8 @@
 * [Use Cases](#UseCases)
   * [_Trusted_ Third Party Scripts](#Trusted_ThirdPartyScripts)
   * [Code Testing](#CodeTesting)
-    * [Running tests in a Realm](#RunningtestsinaRealm)
-    * [Test FWs + Tooling to run tests in a realm](#TestFWsToolingtoruntestsinarealm)
+    * [Running tests in a ShadowRealm](#RunningtestsinaRealm)
+    * [Test FWs + Tooling to run tests in a shadowRealm](#TestFWsToolingtoruntestsinarealm)
   * [Codebase segmentation](#Codebasesegmentation)
   * [Template libraries](#Templatelibraries)
   * [DOM Virtualization](#DOMVirtualization)
@@ -33,11 +33,11 @@
 
 ## <a name='Introduction'></a>Introduction
 
-The Realms proposal provides a new mechanism to execute JavaScript code within the context of a new global object and set of JavaScript built-ins.
+The ShadowRealms proposal provides a new mechanism to execute JavaScript code within the context of a new global object and set of JavaScript built-ins.
 
 The API enables control over the execution of different programs within a Realm, providing a proper mechanism for virtualization. This is not possible in the Web Platform today and the proposed API is aimed to a seamless solution for all JS enviroments.
 
-There are various examples where Realms can be well applied to:
+There are various examples where ShadowRealms can be well applied to:
 
   * Web-based IDEs or any kind of 3rd party code execution using same origin evaluation policies.
   * DOM Virtualization (e.g.: Google AMP)
@@ -53,10 +53,10 @@ This document expands a list of some of these [use cases with examples](#UseCase
 
 ## <a name='APITypeScriptFormat'></a>API (TypeScript Format)
 
-This is The Realms API description in TypeScript format:
+This is The ShadowRealm API description in TypeScript format:
 
 ```ts
-declare class Realm {
+declare class ShadowRealm {
     constructor();
     importValue(specifier: string, bindingName: string): Promise<PrimitiveValueOrCallable>;
     evaluate(sourceText: string): PrimitiveValueOrCallable;
@@ -65,15 +65,15 @@ declare class Realm {
 
 The proposed specification defines:
 
-- The [`constructor`](https://tc39.es/proposal-realms/#sec-realm).
-- The [`Realm#importValue()`](https://tc39.es/proposal-realms/#sec-realm.prototype.importValue) method, equivalent to the `import()` expression, but capturing a primitive or callable values.
-- The [`get Realm#evaluate`](https://tc39.es/proposal-realms/#sec-realm.prototype.evaluate) method promotes an indirect eval in the realm but only allows the return of primitive or callable values.
+- The [`constructor`](https://tc39.es/proposal-shadowrealm/#sec-shadowrealm).
+- The [`ShadowRealm#importValue()`](https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.importValue) method, equivalent to the `import()` expression, but capturing a primitive or callable values.
+- The [`get ShadowRealm#evaluate`](https://tc39.es/proposal-shadowrealm/#sec-shadowrealm.prototype.evaluate) method promotes an indirect eval in the shadowRealm but only allows the return of primitive or callable values.
 - A new wrapped function exotic object with a custom `[[Call]]` internal that has a shared identity of a connected function from another realm associated to it. This identity is not exposed and there is no way to trace back to connected functions cross-realms in user-land.
 
 ### <a name='QuickAPIUsageExample'></a>Quick API Usage Example
 
 ```javascript
-const red = new Realm();
+const red = new ShadowRealm();
 
 // realms can import modules that will execute within it's own environment.
 // When the module is resolved, it captured the binding value, or creates a new
@@ -87,10 +87,10 @@ let result = redAdd(2, 3);
 console.assert(result === 5); // yields true
 
 // The evaluate method can provide quick code evaluation within the constructed
-// realm without requiring any module loading, while it still requires CSP
+// shadowRealm without requiring any module loading, while it still requires CSP
 // relaxing.
 globalThis.someValue = 1;
-red.evaluate('globalThis.someValue = 2'); // Affects only the Realm's global
+red.evaluate('globalThis.someValue = 2'); // Affects only the ShadowRealm's global
 console.assert(globalThis.someValue === 1);
 
 // The wrapped functions can also wrap other functions the other way around.
@@ -118,27 +118,27 @@ In addition to the motivations given above, another commonly-cited motivation is
 
 Finally, a distinct but related problem this proposal could solve is the current inability to completely virtualize the environment where the program should be executed. With this proposal, we are taking a giant step toward that missing feature of the language.
 
-Realms is an often-requested feature from developers, directly or indirectly. It was an original part of the ES6 spec, but it didn't make to the initial cut. This proposal attempts to resolve prior objections and get to a solution that all implementers can agree upon.
+ShadowRealms is an often-requested feature from developers, directly or indirectly. It was an original part of the ES6 spec, but it didn't make to the initial cut. This proposal attempts to resolve prior objections and get to a solution that all implementers can agree upon.
 
-### <a name='Operation'></a>How does Realms operate?
+### <a name='Operation'></a>How does ShadowRealms operate?
 
-Realms execute code with the same JavaScript heap as the surrounding context where the Realm is created. Code runs synchronously in the same thread. Note: The surrounding context is often referenced as the _incubator realm_ within this proposal.
+ShadowRealms execute code with the same JavaScript heap as the surrounding context where the ShadowRealm is created. Code runs synchronously in the same thread. Note: The surrounding context is often referenced as the _incubator realm_ within this proposal.
 
-Same-origin iframes also create a new global object which is synchronously accessible. Realms differ from same-origin iframes by omitting Web APIs such as the DOM, and async config for code injected through dynamic imports. Problems related to identity discontinuity exist in iframes but are not a possibility in Realms as object values are not transferred cross-realms in user land. The only connection exists internally through wrapped functions.
+Same-origin iframes also create a new global object which is synchronously accessible. ShadowRealms differ from same-origin iframes by omitting Web APIs such as the DOM, and async config for code injected through dynamic imports. Problems related to identity discontinuity exist in iframes but are not a possibility in ShadowRealms as object values are not transferred cross-realms in user land. The only connection exists internally through wrapped functions.
 
 Sites like Salesforce.com make extensive use of same-origin iframes to create such global objects. Our experience with same-origin iframes motivated us to steer this proposal forward, which has the following advantages:
 
-- Frameworks would be able to better craft the available API within the global object of the Realm, aiming for what is necessary to evaluate the program.
-- Tailoring up [the exposed set of APIs into the code](#VirtualizedEnvironment) within the Realm provides a better developer experience for a less expensive work compared to tailoring down a full set of exposed APIs - e.g. iframes - that includes handling presence of `[LegacyUnforgeable]` attributes like `window.top`.
-- We hope the usage of Realms will be somewhat lighter weight (both in terms of memory and CPU) for the browser if compared to iframes, especially when frameworks rely on several Realms in the same application.
-- Realms are not accessible from by traversing the DOM of the incubator realm. This will ideal and/or better approach compared to attaching iframes elements and their contentWindow to the DOM. [Detaching iframes](#Iframes) would even add a new own set of problems.
-- A newly created realm does not have immediate access to any object from the incubator realm - and vice-versa - and won't have access to `window.top` as iframes would.
+- Frameworks would be able to better craft the available API within the global object of the ShadowRealm, aiming for what is necessary to evaluate the program.
+- Tailoring up [the exposed set of APIs into the code](#VirtualizedEnvironment) within the ShadowRealm provides a better developer experience for a less expensive work compared to tailoring down a full set of exposed APIs - e.g. iframes - that includes handling presence of `[LegacyUnforgeable]` attributes like `window.top`.
+- We hope the usage of ShadowRealms will be somewhat lighter weight (both in terms of memory and CPU) for the browser if compared to iframes, especially when frameworks rely on several Realms in the same application.
+- ShadowRealms are not accessible from by traversing the DOM of the incubator realm. This will ideal and/or better approach compared to attaching iframes elements and their contentWindow to the DOM. [Detaching iframes](#Iframes) would even add a new own set of problems.
+- A newly created shadowRealm does not have immediate access to any object from the incubator realm - and vice-versa - and won't have access to `window.top` as iframes would.
 
-Realms are complementary to stronger isolation mechanisms such as Workers and cross-origin iframes. They are useful for contexts where synchronous execution is an essential requirement, e.g., emulating the DOM for integration with third-party code. Realms avoid often-prohibitive serialization overhead by using a common heap to the surrounding context.
+ShadowRealms are complementary to stronger isolation mechanisms such as Workers and cross-origin iframes. They are useful for contexts where synchronous execution is an essential requirement, e.g., emulating the DOM for integration with third-party code. ShadowRealms avoid often-prohibitive serialization overhead by using a common heap to the surrounding context.
 
-The Realms API does __not__ introduce a new evaluation mechanism. The code evaluation is subject to the [same restrictions of the incubator realm via CSP](#Evaluation), or any other restriction in Node.
+The ShadowRealm API does __not__ introduce a new evaluation mechanism. The code evaluation is subject to the [same restrictions of the incubator realm via CSP](#Evaluation), or any other restriction in Node.
 
-JavaScript modules are associated with a global object and set of built-ins. Realms contain their own separate module graph which runs in the context of that Realm, so that a full JavaScript development experience is available.
+JavaScript modules are associated with a global object and set of built-ins. ShadowRealms contain their own separate module graph which runs in the context of that ShadowRealm, so that a full JavaScript development experience is available.
 
 ## <a name='Clarifications'></a>Clarifications
 
@@ -148,11 +148,11 @@ In the Web Platform, both `Realm` and `Global Object` are usually associated to 
 
 This proposal is limited to the semantics specified by ECMA-262 with no extra requirements from the web counterparts.
 
-### <a name='TheRealmsGlobalObject'></a>The Realm's Global Object
+### <a name='TheRealmsGlobalObject'></a>The ShadowRealm's Global Object
 
-Each Realm's [Global Object](https://tc39.es/ecma262/#sec-ordinary-object) is an [Ordinary Object](https://tc39.es/ecma262/#sec-ordinary-object). It does not require exotic internals or new primitives.
+Each ShadowRealm's [Global Object](https://tc39.es/ecma262/#sec-ordinary-object) is an [Ordinary Object](https://tc39.es/ecma262/#sec-ordinary-object). It does not require exotic internals or new primitives.
 
-Instances of Realm Objects and their Global Objects have their lifeline to their incubator Realm, they are not _detachable_ from it. Instead, they work as a group, sharing the settings of their incubator Realm. In other words, they act as encapsulation boundaries, they are analogous to a closure or a private field.
+Instances of ShadowRealm Objects and their Global Objects have their lifeline to their incubator Realm, they are not _detachable_ from it. Instead, they work as a group, sharing the settings of their incubator Realm. In other words, they act as encapsulation boundaries, they are analogous to a closure or a private field.
 
 ![](assets/detachable-realms.png)
 
@@ -160,21 +160,21 @@ Instances of Realm Objects and their Global Objects have their lifeline to their
 
 Any code evaluation mechanism in this API is subject to the existing the [Content-Security-Policy (CSP)](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy).
 
-If the CSP directive from a page disallows `unsafe-eval`, it prevents synchronous evaluation in the Realm, i.e.: `Realm#evaluate`.
+If the CSP directive from a page disallows `unsafe-eval`, it prevents synchronous evaluation in the ShadowRealm, i.e.: `ShadowRealm#evaluate`.
 
-The CSP of a page can also set directives like the `default-src` to prevent a Realm from using `Realm#importValue()`.
+The CSP of a page can also set directives like the `default-src` to prevent a ShadowRealm from using `ShadowRealm#importValue()`.
 
 ### <a name='ModuleGraph'></a>Module Graph
 
-Each instance of Realms must have its own Module Graph.
+Each instance of ShadowRealms must have its own Module Graph.
 
 ```javascript
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
 // imports code that executes within its own environment.
-const doSomething = await realm.import('./file.js', 'redDoSomething');
+const doSomething = await shadowRealm.importValue('./file.js', 'redDoSomething');
 
-// This call chains to the realm's redDoSomething
+// This call chains to the shadowRealm's redDoSomething
 doSomething();
 ```
 
@@ -186,12 +186,12 @@ A new [Compartment](https://github.com/tc39/proposal-compartments) provides a ne
 
 ```javascript
 const compartment = new Compartment(options);
-const VirtualizedRealm = compartment.globalThis.Realm;
-const realm = new VirtualizedRealm();
-const { doSomething } = await realm.import('./file.js');
+const VirtualizedRealm = compartment.globalThis.ShadowRealm;
+const shadowRealm = new VirtualizedRealm();
+const { doSomething } = await shadowRealm.importValue('./file.js');
 ```
 
-The Compartments proposal offers a more complex API that offers tailoring over aspects beyond the global APIs but with modifications to internal structure such as module graph. The Realms API just offers immediate access to what is already specified in ECMAScript as it's already structured to distinguish different references from realms.
+The Compartments proposal offers a more complex API that offers tailoring over aspects beyond the global APIs but with modifications to internal structure such as module graph. The ShadowRealm API just offers immediate access to what is already specified in ECMAScript as it's already structured to distinguish different references from realms.
 
 ### <a name='Whynotseparateprocesses'></a>Why not separate processes?
 
@@ -204,11 +204,11 @@ This alternative was discarded for two main reasons:
 
 E.g. Google AMP run in a cross domain iframe, and just want more control about what code they executed in that cross domain application.
 
-There are some identified challenges explained within the current use cases for Realms such as the [WorkerDOM Virtualization challenge for Google AMP](#DOMVirtualization) and the current use of [JSDOM and Node VM modules](#JSDOMvmModules) that would be better placed using an interoperable Realms API as presented by this proposal.
+There are some identified challenges explained within the current use cases for ShadowRealms such as the [WorkerDOM Virtualization challenge for Google AMP](#DOMVirtualization) and the current use of [JSDOM and Node VM modules](#JSDOMvmModules) that would be better placed using an interoperable ShadowRealm API as presented by this proposal.
 
 ## <a name='UseCases'></a>Use Cases
 
-These are some of the key use cases where The Realms API becomes very useful and important:
+These are some of the key use cases where The ShadowRealm API becomes very useful and important:
 
 - Third Party Scripts
 - Code Testing
@@ -220,41 +220,41 @@ These are some of the key use cases where The Realms API becomes very useful and
 
 We acknowledge that applications need a quick and simple execution of Third Party Scripts. There are cases where **many** scripts are executed for the same application. There isn't a need for a new host or agent. This is also not aiming for prevention over non-Trusted Third Party Scripts like malicious code or xss injections. Our focus is on multi libraries and building blocks from different authors.
 
-The Realms API provides integrity preserving semantics - including built-ins - of root and incubator Realms, setting specific boundaries for the Environment Records.
+The ShadowRealm API provides integrity preserving semantics - including built-ins - of root and incubator Realms, setting specific boundaries for the Environment Records.
 
-Third Party Scripts can be executed in a non-blocking asynchronous evaluation through the `Realm#importValue()`.
+Third Party Scripts can be executed in a non-blocking asynchronous evaluation through the `ShadowRealm#importValue()`.
 
-There is no need for immediate access to the application globals - e.g. `window`, `document`. This comes as a convenience for the application that can provide - or not - values and API in different ways. This also creates several opportunities for customization with the Realm Globals and prevent collision with other global values and other third party scripts.
+There is no need for immediate access to the application globals - e.g. `window`, `document`. This comes as a convenience for the application that can provide - or not - values and API in different ways. This also creates several opportunities for customization with the ShadowRealm Globals and prevent collision with other global values and other third party scripts.
 
 ```javascript
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
-// pluginFramework and pluginScript become available in the Realm
+// pluginFramework and pluginScript become available in the ShadowRealm
 const [ init, ready ] = await Promise.all([
-    realm.importValue('./pluginFramework.js', 'init'),
-    realm.importValue('./pluginScript.js', 'ready'),
+    shadowRealm.importValue('./pluginFramework.js', 'init'),
+    shadowRealm.importValue('./pluginScript.js', 'ready'),
 ]);
 
-// The Plugin Script will execute within the Realm
+// The Plugin Script will execute within the ShadowRealm
 init(ready);
 ```
 
 ### <a name='CodeTesting'></a>Code Testing
 
-While multi-threading is useful for testing, the layering enabled from Realms is also great. Test frameworks can use Realms to inject code and also control the order of the injections if necessary.
+While multi-threading is useful for testing, the layering enabled from ShadowRealms is also great. Test frameworks can use ShadowRealms to inject code and also control the order of the injections if necessary.
 
-Testing code can run autonomously within the boundaries set from the Realm object without immediately conflicting with other tests.
+Testing code can run autonomously within the boundaries set from the ShadowRealm object without immediately conflicting with other tests.
 
-#### <a name='RunningtestsinaRealm'></a>Running tests in a Realm
+#### <a name='RunningtestsinaRealm'></a>Running tests in a ShadowRealm
 
 ```javascript
 import { test } from 'testFramework';
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
 const [ runTests, getReportString, suite ] = await Promise.all([
-    realm.importValue('testFramework', 'runTests'),
-    realm.importValue('testFramework', 'getReportString'),
-    realm.importValue('./my-tests.js', 'suite'),
+    shadowRealm.importValue('testFramework', 'runTests'),
+    shadowRealm.importValue('testFramework', 'getReportString'),
+    shadowRealm.importValue('./my-tests.js', 'suite'),
 ]);
 
 // start tests execution
@@ -270,7 +270,7 @@ A big codebase tend to evolve slowly and soon becomes legacy code. Old code vs n
 
 Modifying code to resolve a conflict (e.g.: global variables) is non-trivial, specially in big codebases.
 
-The Realms API can provide a _lightweight_ mechanism to preserve the integrity of the intrinsics. Therefore, it could isolate libraries or logical pieces of the codebase per Realm.
+The ShadowRealm API can provide a _lightweight_ mechanism to preserve the integrity of the intrinsics. Therefore, it could isolate libraries or logical pieces of the codebase per ShadowRealm.
 
 ### <a name='DOMVirtualization'></a>DOM Virtualization
 
@@ -279,10 +279,10 @@ We still want things to interact with the DOM without spending any excessive amo
 It is important for applications to emulate the DOM as best as possible. Requiring authors to change their code to run in our virtualized environment is difficult. Specially if they are using third party libraries.
 
 ```javascript
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
-const initVirtualDocument = await realm.importValue('virtual-document', 'init');
-await realm.importValue('./publisher-amin.js', 'symbolId');
+const initVirtualDocument = await shadowRealm.importValue('virtual-document', 'init');
+await shadowRealm.importValue('./publisher-amin.js', 'symbolId');
 
 init();
 ```
@@ -299,20 +299,20 @@ The communication is also limited by serialization aspects of [transferable obje
 
 JSDOM [relies on VM](https://github.com/jsdom/jsdom/blob/0b1f84f499a0b23fad054228b34412869f940765/lib/jsdom/living/nodes/HTMLScriptElement-impl.js#L221-L248) functionality to emulate the __HTMLScriptElement__ and maintains a [shim of the vm module](https://github.com/jsdom/jsdom/blob/bfe7de63d6b1841053d572a915b2ff06bd4357b9/lib/jsdom/vm-shim.js) when it is bundled to run in a webpage where it doesn’t have access to the Node's __vm__ module.
 
-The Realms API provides a single API for this virtualization in both browsers and NodeJS.
+The ShadowRealm API provides a single API for this virtualization in both browsers and NodeJS.
 
 ### <a name='VirtualizedEnvironment'></a>Virtualized Environment
 
 The usage of different realms allow customized access to the global environment. To start, The global object could be immediately frozen.
 
 ```javascript
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
-realm.evaluate('Object.freeze(globalThis), 0');
+shadowRealm.evaluate('Object.freeze(globalThis), 0');
 
 // or without CSP relaxing:
 
-const freezeRealmGlobal = await realm.importValue('./inside-code.js', 'reflectFreezeRealmGlobal');
+const freezeRealmGlobal = await shadowRealm.importValue('./inside-code.js', 'reflectFreezeRealmGlobal');
 
 /**
  * inside-code.js
@@ -330,7 +330,7 @@ const freezeRealmGlobal = await realm.importValue('./inside-code.js', 'reflectFr
 freezeRealmGlobal();
 ```
 
-In web browsers, this is currently not possible. The way to get manage new Realms would be through iframes, but they also share a window proxy object.
+In web browsers, this is currently not possible. The way to get manage new ShadowRealms would be through iframes, but they also share a window proxy object.
 
 ```javascript
 const iframe = document.createElement('iframe');
@@ -340,24 +340,24 @@ const rGlobal = iframe.contentWindow; // same as iframe.contentWindow.globalThis
 Object.freeze(rGlobal); // TypeError, cannot freeze window proxy
 ```
 
-The same iframe approach won't also have a direct access to import modules dynamically. The usage of `realm.importValue` is possible instead of roughly using eval functions or setting _script type module_ in the iframe, if available.
+The same iframe approach won't also have a direct access to import modules dynamically. The usage of `shadowRealm.importValue` is possible instead of roughly using eval functions or setting _script type module_ in the iframe, if available.
 
 #### <a name='DOMmocking'></a>DOM mocking
 
-The Realms API allows a much smarter approach for DOM mocking, where the globalThis can be setup in userland:
+The ShadowRealm API allows a much smarter approach for DOM mocking, where the globalThis can be setup in userland:
 
 ```javascript
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
-const installFakeDOM = await realm.importValue('./fakedom.js', 'default');
+const installFakeDOM = await shadowRealm.importValue('./fakedom.js', 'default');
 
-// Custom properties can be added to the Realm
+// Custom properties can be added to the ShadowRealm
 installFakeDOM();
 ```
 
-This code allows a customized set of properties to each new Realm - e.g. `document` - and avoid issues on handling immutable accessors/properties from the Window proxy. e.g.: `window.top`, `window.location`, etc..
+This code allows a customized set of properties to each new ShadowRealm - e.g. `document` - and avoid issues on handling immutable accessors/properties from the Window proxy. e.g.: `window.top`, `window.location`, etc..
 
-This explainer document speculates a `installFakeDOM` API to set up a proper frame emulation. We understand there might be many ways to explore how to emulate frames with plenty of room for improvement, as seen in [some previous discussions](https://github.com/tc39/proposal-realms/issues/268#issuecomment-674338593), as in the following pseudo-code:
+This explainer document speculates a `installFakeDOM` API to set up a proper frame emulation. We understand there might be many ways to explore how to emulate frames with plenty of room for improvement, as seen in [some previous discussions](https://github.com/tc39/proposal-shadowrealm/issues/268#issuecomment-674338593), as in the following pseudo-code:
 
 ```javascript
 export default function() {
@@ -390,9 +390,9 @@ function extractIntrinsicsFromGlobal(customGlobalThis) {
 
 ## <a name='Modules'></a>Modules
 
-In principle, the Realm proposal does not provide the controls for the module graphs. Every new Realm initializes its own module graph, while any invocation to `Realm.prototype.importValue()` method, or by using `import()` when evaluating code inside the realm through wrapped functions, will populate this module graph. This is analogous to same-domain iframes, and VM in nodejs.
+In principle, the ShadowRealm proposal does not provide the controls for the module graphs. Every new ShadowRealm initializes its own module graph, while any invocation to `ShadowRealm.prototype.importValue()` method, or by using `import()` when evaluating code inside the shadowRealm through wrapped functions, will populate this module graph. This is analogous to same-domain iframes, and VM in nodejs.
 
-However, the [Compartments](https://github.com/tc39/proposal-compartments) proposal plans to provide the low level hooks to control the module graph per Realm. This is one of the intersection semantics between the two proposals.
+However, the [Compartments](https://github.com/tc39/proposal-compartments) proposal plans to provide the low level hooks to control the module graph per ShadowRealm. This is one of the intersection semantics between the two proposals.
 
 ## <a name='Integrity'></a>Integrity
 
@@ -400,7 +400,7 @@ We believe that realms can be a good complement to integrity mechanisms by provi
 
 * Google News App creates multiples sub-apps that can be presented to the user.
 * Each sub-app runs in a cross-domain iframe (communicating with the main app via post-message).
-* Each vendor (one per app) can attempt to enhance their sub-app that display their content by executing their code in a realm that provide access to a well defined set of APIs to preserve the integrity of the sub-app.
+* Each vendor (one per app) can attempt to enhance their sub-app that display their content by executing their code in a shadowRealm that provide access to a well defined set of APIs to preserve the integrity of the sub-app.
 
 There are many examples like this for the web: Google Sheets, Figma's plugins, or Salesforce's Locker Service for Web Components.
 
@@ -417,11 +417,11 @@ Importing modules allow us to run asynchronous executions with set boundaries fo
 ```javascript
 globalThis.blueValue = "a global value";
 
-const r = new Realm();
+const r = new ShadowRealm();
 
 r.importValue("./sandbox.js", "test").then(test => {
 
-  // globals in the incubator realm are not leaked to the constructed realm
+  // globals in the incubator shadowRealm are not leaked to the constructed shadowRealm
   test("blueValue"); // undefined
   test("redValue"); // 42
 });
@@ -432,7 +432,7 @@ r.importValue("./sandbox.js", "test").then(test => {
 ```javascript
 // blueValue is not available as a global name here
 
-// Names here are not leaked to the incubator realm
+// Names here are not leaked to the incubator shadowRealm
 globalThis.redValue = 42;
 
 export function test(property) {
@@ -440,9 +440,9 @@ export function test(property) {
 }
 ```
 
-### <a name='Example:iframesvsRealms'></a>Example: iframes vs Realms
+### <a name='Example:iframesvsRealms'></a>Example: iframes vs ShadowRealms
 
-If you're using anonymous iframes today to "evaluate" javascript code in a different realm, you can replace it with a new Realm, as a more performant option, without identity discontinuity, e.g.:
+If you're using anonymous iframes today to "evaluate" javascript code in a different realm, you can replace it with a new ShadowRealm, as a more performant option, without identity discontinuity, e.g.:
 
 ```javascript
 const globalOne = window;
@@ -459,11 +459,11 @@ list instanceof Array; // false
 Array.isArray(list); // true
 ```
 
-This code is **not** possible with the Realms API! Non-primitive values are not transfered cross-realms using the Realms API.
+This code is **not** possible with the ShadowRealm API! Non-primitive values are not transfered cross-realms using the ShadowRealm API.
 
-## <a name='Example:NodesvmobjectsvsRealms'></a>Example: Node's vm objects vs Realms
+## <a name='Example:NodesvmobjectsvsRealms'></a>Example: Node's vm objects vs ShadowRealms
 
-If you're using node's `vm` module today to "evaluate" javascript code in a different realm, you can replace some of its usage with a new Realm, e.g.:
+If you're using node's `vm` module today to "evaluate" javascript code in a different realm, you can replace some of its usage with a new ShadowRealm, e.g.:
 
 ```javascript
 const vm = require('vm');
@@ -480,9 +480,9 @@ script.runInContext(new vm.createContext());
 will become:
 
 ```javascript
-const realm = new Realm();
+const shadowRealm = new ShadowRealm();
 
-const result = realm.evaluate(`
+const result = shadowRealm.evaluate(`
 function add(a, b) {
   return a + b;
 }
@@ -500,7 +500,7 @@ The current status quo is using VM module in nodejs, and same-domain iframes in 
 
 ## <a name='Iframes'></a>Iframes
 
-Developers can technically already create a new Realm by creating a new same-domain iframe, but there are a few impediments to using this as a reliable mechanism:
+Developers can technically already create a new ShadowRealm by creating a new same-domain iframe, but there are a few impediments to using this as a reliable mechanism:
 
 * the global object of the iframe is a window proxy, which implements a bizarre behavior, including its unforgeable proto chain.
 * There are multiple ~~unforgeable~~ unvirtualizable objects due to the DOM semantics, this makes it almost impossible to eliminate certain capabilities while downgrading the window to a brand new global without DOM.
@@ -531,9 +531,9 @@ iframeWindow.top;
 
 ## <a name='FAQ'></a>FAQ
 
-### So do Realms only have the ECMAScript APIs available?
+### So do ShadowRealms only have the ECMAScript APIs available?
 
-Yes! It only creates a new copy of the built-ins from ECMAScript. Although, we have open discussions about additional [HTML properties](https://github.com/tc39/proposal-realms/issues/284) or [some intrinsics subset](https://github.com/tc39/proposal-realms/issues/288).
+Yes! It only creates a new copy of the built-ins from ECMAScript. Although, we have open discussions about additional [HTML properties](https://github.com/tc39/proposal-shadowrealm/issues/284) or [some intrinsics subset](https://github.com/tc39/proposal-shadowrealm/issues/288).
 
 ### Most libraries won't work unless they add dependencies manually
 
@@ -541,10 +541,10 @@ Yes! It only creates a new copy of the built-ins from ECMAScript. Although, we h
 
 Absolutely, this is equivalent to what happens to [Node VM](https://nodejs.org/api/vm.html) today as a low level API prior art. As a developer you need to setup the environment to execute code.
 
-Ideally the Realms would arrive a clean state, allowing tailoring for what is necessary to be added. This contrasts with the tailoring over unforgeables. e.g. `window.top`, `window.location`, etc
+Ideally the ShadowRealms would arrive a clean state, allowing tailoring for what is necessary to be added. This contrasts with the tailoring over unforgeables. e.g. `window.top`, `window.location`, etc
 
 Considering all the trade offs, the clean state seems the best option, in our opinion. It allows tailoring for multiple purposes and comprehends more use cases.
 
 ### Exploration ahead
 
-There is more to explore ahead for Realms, but not yet for this current proposal. The current API is good enough to enable synchronous execution of code and membranes implementation, even if setup might require async import for code injection.
+There is more to explore ahead for ShadowRealms, but not yet for this current proposal. The current API is good enough to enable synchronous execution of code and membranes implementation, even if setup might require async import for code injection.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ecma-proposal-realms",
+  "name": "ecma-proposal-shadowrealm",
   "version": "1.0.0",
-  "description": "ECMAScript spec proposal for Realms API",
+  "description": "ECMAScript spec proposal for ShadowRealm API",
   "license": "Apache-2.0",
   "author": {
     "name": "TC39 Open Source Contributors"
@@ -15,13 +15,13 @@
     "spec",
     "proposal"
   ],
-  "homepage": "https://github.com/tc39/proposal-realms#readme",
+  "homepage": "https://github.com/tc39/proposal-shadowrealm#readme",
   "bugs": {
-    "url": "https://github.com/tc39/proposal-realms/issues"
+    "url": "https://github.com/tc39/proposal-shadowrealm/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tc39/proposal-realms.git"
+    "url": "git+https://github.com/tc39/proposal-shadowrealm.git"
   },
   "scripts": {
     "prebuild": "mkdir -p dist",

--- a/spec.html
+++ b/spec.html
@@ -253,7 +253,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Set _O_.[[ExecutionContext]] to _context_.
 				1. Perform ? SetRealmGlobalObject(_realmRec_, *undefined*, *undefined*).
 				1. Perform ? SetDefaultGlobalBindings(_O_.[[ShadowRealm]]).
-				1. Perform ? HostInitializeSyntheticRealm(_O_.[[ShadowRealm]]).
+				1. Perform ? HostInitializeShadowRealm(_O_.[[ShadowRealm]]).
 				1. Return _O_.
 			</emu-alg>
 		</emu-clause>
@@ -368,10 +368,10 @@ location: https://tc39.es/proposal-shadowrealm/
 
 	<emu-clause id="sec-shadowrealm-host-operations">
 		<h1>Host operations</h1>
-		<emu-clause id="sec-host-initialize-synthetic-shadowrealm" aoid="HostInitializeSyntheticRealm">
-			<h1>Runtime Semantics: HostInitializeSyntheticRealm ( _realm_ )</h1>
+		<emu-clause id="sec-host-initialize-shadow-shadowrealm" aoid="HostInitializeShadowRealm">
+			<h1>Runtime Semantics: HostInitializeShadowRealm ( _realm_ )</h1>
 			<p>
-				HostInitializeSyntheticRealm is an implementation-defined abstract
+				HostInitializeShadowRealm is an implementation-defined abstract
 				operation used to inform the host of any newly created realms from
 				the ShadowRealm constructor. Its return value is not used, though it may
 				throw an exception. The idea of this hook is to initialize host

--- a/spec.html
+++ b/spec.html
@@ -9,12 +9,12 @@
 
 <body>
 <pre class="metadata">
-title: 'Realms API'
+title: 'ShadowRealm API'
 stage: 2
 contributors: Dave Herman, Caridy Patiño, Mark Miller, Leo Balter
 status: proposal
 copyright: false
-location: https://tc39.es/proposal-realms/
+location: https://tc39.es/proposal-shadowrealm/
 </pre>
 <emu-biblio href="./biblio.json"></emu-biblio>
 
@@ -29,9 +29,9 @@ location: https://tc39.es/proposal-realms/
 					<th>ECMAScript Language Association</th>
 				</tr>
 				<tr>
-					<td>%Realm%</td>
-					<td>`Realm`</td>
-					<td>The Realm constructor (<emu-xref href="#sec-realm-constructor"></emu-xref>)</td>
+					<td>%ShadowRealm%</td>
+					<td>`ShadowRealm`</td>
+					<td>The ShadowRealm constructor (<emu-xref href="#sec-shadowrealm-constructor"></emu-xref>)</td>
 				</tr>
 			</tbody>
 		</table>
@@ -125,10 +125,10 @@ location: https://tc39.es/proposal-realms/
 	</emu-clause>
 </emu-clause>
 
-<emu-clause id="sec-realm-objects">
-	<h1>Realm Objects</h1>
-	<emu-clause id="sec-realm-abstracts">
-		<h1>Realm Abstract Operations</h1>
+<emu-clause id="sec-shadowrealm-objects">
+	<h1>ShadowRealm Objects</h1>
+	<emu-clause id="sec-shadowrealm-abstracts">
+		<h1>ShadowRealm Abstract Operations</h1>
 
 		<emu-clause id="sec-performrealmeval" aoid="PerformRealmEval">
 			<h1>PerformRealmEval ( _sourceText_, _callerRealm_, _evalRealm_ )</h1>
@@ -179,14 +179,14 @@ location: https://tc39.es/proposal-realms/
 			</emu-note>
 		</emu-clause>
 
-		<emu-clause id="sec-realmimportvalue" aoid="RealmImportValue">
-			<h1>RealmImportValue ( _specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_ )</h1>
+		<emu-clause id="sec-shadowrealmimportvalue" aoid="ShadowRealmImportValue">
+			<h1>ShadowRealmImportValue ( _specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_ )</h1>
 			<emu-alg>
 				1. Assert: Type(_specifierString_) is String.
 				1. Assert: Type(_exportNameString_) is String.
 				1. Assert: _callerRealm_ is a Realm Record.
 				1. Assert: _evalRealm_ is a Realm Record.
-				1. Assert: _evalContext_ is an execution context associated to a Realm instance's [[ExecutionContext]].
+				1. Assert: _evalContext_ is an execution context associated to a ShadowRealm instance's [[ExecutionContext]].
 				1. Let _innerCapability_ be ! NewPromiseCapability(%Promise%).
 				1. Let _runningContext_ be the running execution context.
 				1. If _runningContext_ is not already suspended, suspend _runningContext_.
@@ -210,7 +210,7 @@ location: https://tc39.es/proposal-realms/
 				1. Let _hasOwn_ be ? HasOwnProperty(_exports_, _string_).
 				1. If _hasOwn_ is *false*, throw a *TypeError* exception.
 				1. Let _value_ be ? Get(_exports_, _string_).
-				1. Let _realm_ be _f_.[[Realm]].
+				1. Let _realm_ be _f_.[[ShadowRealm]].
 				1. Return ? GetWrappedValue(_realm_, _value_).
 			</emu-alg>
 		</emu-clause>
@@ -227,74 +227,74 @@ location: https://tc39.es/proposal-realms/
 		</emu-clause>
 	</emu-clause>
 
-	<emu-clause id="sec-realm-constructor">
-		<h1>The Realm Constructor</h1>
-		<p>The Realm constructor:</p>
+	<emu-clause id="sec-shadowrealm-constructor">
+		<h1>The ShadowRealm Constructor</h1>
+		<p>The ShadowRealm constructor:</p>
 		<ul>
-			<li>is the intrinsic object <dfn>%Realm%</dfn>.</li>
-			<li>is the initial value of the *"Realm"* property of the global object.</li>
+			<li>is the intrinsic object <dfn>%ShadowRealm%</dfn>.</li>
+			<li>is the initial value of the *"ShadowRealm"* property of the global object.</li>
 			<li>is not intended to be called as a function and will throw an exception when called in that manner.</li>
-			<li>creates and initializes a new Realm object when called as a constructor.</li>
-			<li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `Realm` behaviour must include a `super` call to the `Realm` constructor to create and initialize the subclass instance with the internal state necessary to support the `Realm.prototype` built-in methods.</li>
+			<li>creates and initializes a new ShadowRealm object when called as a constructor.</li>
+			<li>is designed to be subclassable. It may be used as the value in an `extends` clause of a class definition. Subclass constructors that intend to inherit the specified `ShadowRealm` behaviour must include a `super` call to the `ShadowRealm` constructor to create and initialize the subclass instance with the internal state necessary to support the `ShadowRealm.prototype` built-in methods.</li>
 		</ul>
 
-		<emu-clause id="sec-realm">
-			<h1>Realm ( )</h1>
-			<p>When the `Realm` function is called, the following steps are taken:</p>
+		<emu-clause id="sec-shadowrealm">
+			<h1>ShadowRealm ( )</h1>
+			<p>When the `ShadowRealm` function is called, the following steps are taken:</p>
 			<emu-alg>
 				1. If NewTarget is *undefined*, throw a *TypeError* exception.
-				1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%Realm.prototype%"*, « [[Realm]], [[ExecutionContext]] »).
+				1. Let _O_ be ? OrdinaryCreateFromConstructor(NewTarget, *"%ShadowRealm.prototype%"*, « [[ShadowRealm]], [[ExecutionContext]] »).
 				1. Let _realmRec_ be CreateRealm().
-				1. Set _O_.[[Realm]] to _realmRec_.
+				1. Set _O_.[[ShadowRealm]] to _realmRec_.
 				1. Let _context_ be a new execution context.
 				1. Set the Function of _context_ to *null*.
 				1. Set the Realm of _context_ to _realmRec_.
 				1. Set the ScriptOrModule of _context_ to *null*.
 				1. Set _O_.[[ExecutionContext]] to _context_.
 				1. Perform ? SetRealmGlobalObject(_realmRec_, *undefined*, *undefined*).
-				1. Perform ? SetDefaultGlobalBindings(_O_.[[Realm]]).
-				1. Perform ? HostInitializeSyntheticRealm(_O_.[[Realm]]).
+				1. Perform ? SetDefaultGlobalBindings(_O_.[[ShadowRealm]]).
+				1. Perform ? HostInitializeSyntheticRealm(_O_.[[ShadowRealm]]).
 				1. Return _O_.
 			</emu-alg>
 		</emu-clause>
 	</emu-clause>
 
-	<emu-clause id="sec-properties-of-the-realm-constructor">
-		<h1>Properties of the Realm Constructor</h1>
-		<p>The Realm constructor:</p>
+	<emu-clause id="sec-properties-of-the-shadowRealm-constructor">
+		<h1>Properties of the ShadowRealm Constructor</h1>
+		<p>The ShadowRealm constructor:</p>
 		<ul>
 			<li>has a [[Prototype]] internal slot whose value is %Function.prototype%.</li>
 			<li>has the following properties:</li>
 		</ul>
 
-		<emu-clause id="sec-realm.prototype">
-			<h1>Realm.prototype</h1>
-			<p>The initial value of *Realm.prototype* is %Realm.prototype%.</p>
+		<emu-clause id="sec-shadowrealm.prototype">
+			<h1>ShadowRealm.prototype</h1>
+			<p>The initial value of *ShadowRealm.prototype* is %ShadowRealm.prototype%.</p>
 			<p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *false* }.</p>
 		</emu-clause>
 	</emu-clause>
 
-	<emu-clause id="sec-properties-of-the-realm-prototype-object">
-		<h1>Properties of the Realm Prototype Object</h1>
-		<p>The Realm prototype object:</p>
+	<emu-clause id="sec-properties-of-the-shadowrealm-prototype-object">
+		<h1>Properties of the ShadowRealm Prototype Object</h1>
+		<p>The ShadowRealm prototype object:</p>
 		<ul>
 			<li>has a [[Prototype]] internal slot whose value is <dfn>%Object.prototype%</dfn>.</li>
-			<li>is %Realm.prototype%.</li>
+			<li>is %ShadowRealm.prototype%.</li>
 			<li>is an ordinary object.</li>
-			<li>does not have a [[Realm]] or any other of the internal slots that are specific to _Realm_ instance objects.</li>
+			<li>does not have a [[ShadowRealm]] or any other of the internal slots that are specific to _Realm_ instance objects.</li>
 		</ul>
 
-		<emu-clause id="sec-realm.prototype.eval">
-			<h1>Realm.prototype.evaluate ( _sourceText_ )</h1>
+		<emu-clause id="sec-shadowrealm.prototype.evaluate">
+			<h1>ShadowRealm.prototype.evaluate ( _sourceText_ )</h1>
 
-			<p>Synchronously execute a top-level script. The _sourceText_ is interpreted as a Script and evaluated with this bound to the realm's global object.</p>
+			<p>Synchronously execute a top-level script. The _sourceText_ is interpreted as a Script and evaluated with this bound to the shadowrealm's global object.</p>
 
 			<emu-alg>
 				1. Let _O_ be *this* value.
 				1. Perform ? ValidateRealmObject(_O_).
 				1. If Type(_sourceText_) is not String, throw a *TypeError* exception.
 				1. Let _callerRealm_ be the current Realm Record.
-				1. Let _evalRealm_ be _O_.[[Realm]].
+				1. Let _evalRealm_ be _O_.[[ShadowRealm]].
 				1. Return ? PerformRealmEval(_sourceText_, _callerRealm_, _evalRealm_).
 			</emu-alg>
 
@@ -303,8 +303,8 @@ location: https://tc39.es/proposal-realms/
 			</emu-note>
 		</emu-clause>
 
-		<emu-clause id="sec-realm.prototype.importValue">
-			<h1>Realm.prototype.importValue ( _specifier_, _exportName_ )</h1>
+		<emu-clause id="sec-shadowrealm.prototype.importvalue">
+			<h1>ShadowRealm.prototype.importValue ( _specifier_, _exportName_ )</h1>
 			<p>The following steps are performed:</p>
 			<emu-alg>
 				1. Let _O_ be *this* value.
@@ -312,9 +312,9 @@ location: https://tc39.es/proposal-realms/
 				1. Let _specifierString_ be ? ToString(_specifier_).
 				1. Let _exportNameString_ be ? ToString(_exportName_).
 				1. Let _callerRealm_ be the current Realm Record.
-				1. Let _evalRealm_ be _O_.[[Realm]].
+				1. Let _evalRealm_ be _O_.[[ShadowRealm]].
 				1. Let _evalContext_ be _O_.[[ExecutionContext]].
-				1. Return ? RealmImportValue(_specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_).
+				1. Return ? ShadowRealmImportValue(_specifierString_, _exportNameString_, _callerRealm_, _evalRealm_, _evalContext_).
 			</emu-alg>
 
 			<emu-note type=editor>
@@ -327,23 +327,23 @@ location: https://tc39.es/proposal-realms/
 			<p>The abstract operation ValidateRealmObject takes argument _argument_. It performs the following steps when called:</p>
 
 			<emu-alg>
-				1. Perform ? RequireInternalSlot(_O_, [[Realm]]).
+				1. Perform ? RequireInternalSlot(_O_, [[ShadowRealm]]).
 				1. Perform ? RequireInternalSlot(_O_, [[ExecutionContext]]).
 			</emu-alg>
 		</emu-clause>
 
-		<emu-clause id="sec-realm.prototype-@@tostringtag">
-			<h1>Realm.prototype [ @@toStringTag ]</h1>
-			<p>The initial value of the @@toStringTag property is the String value *"Realm"*.</p>
+		<emu-clause id="sec-shadowrealm.prototype-@@tostringtag">
+			<h1>ShadowRealm.prototype [ @@toStringTag ]</h1>
+			<p>The initial value of the @@toStringTag property is the String value *"ShadowRealm"*.</p>
 			<p>This property has the attributes { [[Writable]]: *false*, [[Enumerable]]: *false*, [[Configurable]]: *true* }.</p>
 		</emu-clause>
 	</emu-clause>
 
-	<emu-clause id="sec-properties-of-realm-instances">
-		<h1>Properties of Realm Instances</h1>
-		<p>Realm instances are ordinary objects that inherit properties from the Realm prototype object (the intrinsic, %Realm.prototype%). Realm instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-realm-instances"></emu-xref>.</p>
+	<emu-clause id="sec-properties-of-shadowrealm-instances">
+		<h1>Properties of ShadowRealm Instances</h1>
+		<p>ShadowRealm instances are ordinary objects that inherit properties from the ShadowRealm prototype object (the intrinsic, %ShadowRealm.prototype%). ShadowRealm instances are initially created with the internal slots described in <emu-xref href="#table-internal-slots-of-shadowrealm-instances"></emu-xref>.</p>
 
-		<emu-table id="table-internal-slots-of-realm-instances" caption="Internal Slots of Realm Instances">
+		<emu-table id="table-internal-slots-of-shadowrealm-instances" caption="Internal Slots of ShadowRealm Instances">
 			<table>
 				<tbody>
 					<tr>
@@ -352,33 +352,33 @@ location: https://tc39.es/proposal-realms/
 						<th>Description</th>
 					</tr>
 					<tr>
-						<td>[[Realm]]</td>
+						<td>[[ShadowRealm]]</td>
 						<td>Realm Record</td>
 						<td>The Realm Record for the initial execution context.</td>
 					</tr>
 					<tr>
 						<td>[[ExecutionContext]]</td>
 						<td>Execution context</td>
-						<td>An execution context wherein the current Realm is this [[Realm]].</td>
+						<td>An execution context wherein the current Realm is this [[ShadowRealm]].</td>
 					</tr>
 				</tbody>
 			</table>
 		</emu-table>
 	</emu-clause>
 
-	<emu-clause id="sec-realm-host-operations">
+	<emu-clause id="sec-shadowrealm-host-operations">
 		<h1>Host operations</h1>
-		<emu-clause id="sec-host-initialize-synthetic-realm" aoid="HostInitializeSyntheticRealm">
+		<emu-clause id="sec-host-initialize-synthetic-shadowrealm" aoid="HostInitializeSyntheticRealm">
 			<h1>Runtime Semantics: HostInitializeSyntheticRealm ( _realm_ )</h1>
 			<p>
 				HostInitializeSyntheticRealm is an implementation-defined abstract
 				operation used to inform the host of any newly created realms from
-				the Realm constructor. Its return value is not used, though it may
+				the ShadowRealm constructor. Its return value is not used, though it may
 				throw an exception. The idea of this hook is to initialize host
-				data structures related to the Realm, e.g., for module loading.
+				data structures related to the ShadowRealm, e.g., for module loading.
 			</p>
 			<p>
-				The host may use this hook to add properties to the Realm's global
+				The host may use this hook to add properties to the ShadowRealm's global
 				object. Those properties must be configurable.
 			</p>
 			<emu-note>
@@ -393,7 +393,7 @@ location: https://tc39.es/proposal-realms/
 			</emu-note>
 			<emu-note type=editor>
 				<p>
-					The Realm constructor (<emu-xref href="#sec-realm"></emu-xref>
+					The ShadowRealm constructor (<emu-xref href="#sec-shadowrealm"></emu-xref>
 					creates a new global object as an ordinary object. This
 					means all properties from the global object are deletable.
 				</p>


### PR DESCRIPTION
This required some manual curation as some instances of Realm needs to be preserving and not being renamed to ShadowRealm. e.g.: `The Realm Record`, `incubator realm`, or general content about multiple realms.

This change achieved consensus at the TC39 meeting in September 2021.