### PR TITLE
Add WrappedFunction.[[Realm]] internal slot

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -81,6 +81,17 @@ location: https://tc39.es/proposal-shadowrealm/
 			Executes code associated with this object's [[WrappedTargetFunction]].
 		</td>
 		</tr>
+		<tr>
+		<td>
+			[[Realm]]
+		</td>
+		<td>
+			Realm Record
+		</td>
+		<td>
+			The realm in which the function was created.
+		</td>
+		</tr>
 		</tbody>
 	</table>
 	</emu-table>
@@ -120,6 +131,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Set _obj_.[[Prototype]] to _callerRealm_.[[Intrinsics]].[[%Function.prototype%]].
 			1. Set _obj_.[[Call]] as described in <emu-xref href="#sec-wrapped-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
 			1. Set _obj_.[[WrappedTargetFunction]] to _targetFunction_.
+			1. Set _obj_.[[Realm]] to _callerRealm_.
 			1. Return _obj_.
 		</emu-alg>
 	</emu-clause>


### PR DESCRIPTION
`GetFunctionRealm` in Step 4 of #sec-wrapped-function-exotic-objects-call-thisargument-argumentslist
requires the function object to own an internal slot of [[Realm]] or the current execution realm record will be 
returned instead, which can differ from the creation realm.