### PR TITLE
[DON'T MERGE THIS] Normative: Allow transferring SharedArrayBuffer objects

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -232,18 +232,16 @@ location: https://tc39.es/proposal-shadowrealm/
 			<h1>GetTransferrableValue ( _receiverRealm_, _value_ )</h1>
 			<emu-alg>
 				1. Assert: _receiverRealm_ is a Realm Record.
-				1. If Type(_value_) is Object, then
-					1. If IsCallable(_value_) is *true*,
-						1. Return ! WrappedFunctionCreate(_receiverRealm_, _value_).
-					1. If _value_ has an [[ArrayBufferData]] internal slot, then
-						1. If IsSharedArrayBuffer(_value_) is *true*, then
-							1. Let _clone_ be ! OrdinaryObjectCreate(_receiverRealm_.[[Intrinsics]].%SharedArrayBuffer.prototype%, « [[ArrayBufferData]], [[ArrayBufferByteLength]] »).
-							1. Assert: _value_ and _clone_ are instances of SharedArrayBuffer of different Realms each.
-							1. Set _clone_.[[ArrayBufferData]] to _value_.[[ArrayBufferData]].
-							1. Set _clone_.[[ArrayBufferByteLength]] to _value_.[[ArrayBufferByteLength]].
-							1. Return _clone_.
-					1. Throw a TypeError exception.
-				1. Return _value_.
+				1. If Type(_value_) is not Object, return _value_.
+				1. If IsCallable(_value_) is *true*,
+					1. Return ! WrappedFunctionCreate(_receiverRealm_, _value_).
+				1. If _value_ has an [[ArrayBufferData]] internal slot, and if IsSharedArrayBuffer(_value_) is *true*, then
+					1. Let _clone_ be ! OrdinaryObjectCreate(_receiverRealm_.[[Intrinsics]].%SharedArrayBuffer.prototype%, « [[ArrayBufferData]], [[ArrayBufferByteLength]] »).
+					1. Assert: _value_ and _clone_ are instances of SharedArrayBuffer of different Realms each.
+					1. Set _clone_.[[ArrayBufferData]] to _value_.[[ArrayBufferData]].
+					1. Set _clone_.[[ArrayBufferByteLength]] to _value_.[[ArrayBufferByteLength]].
+					1. Return _clone_.
+				1. Throw a TypeError exception.
 			</emu-alg>
 		</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -107,12 +107,12 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. NOTE: Any exception objects produced after this point are associated with _callerRealm_.
 			1. Let _wrappedArgs_ be a new empty List.
 			1. For each element _arg_ of _argumentsList_, do
-				1. Let _wrappedValue_ be ? GetWrappedValue(_targetRealm_, _arg_).
+				1. Let _wrappedValue_ be ? GetTransferrableValue(_targetRealm_, _arg_).
 				1. Append _wrappedValue_ to _wrappedArgs_.
-			1. Let _wrappedThisArgument_ to ? GetWrappedValue(_targetRealm_, _thisArgument_).
+			1. Let _wrappedThisArgument_ to ? GetTransferrableValue(_targetRealm_, _thisArgument_).
 			1. Let _result_ be the Completion Record of Call(_target_, _wrappedThisArgument_, _wrappedArgs_).
 			1. If _result_.[[Type]] is ~normal~ or _result_.[[Type]] is ~return~, then
-				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
+				1. Return ? GetTransferrableValue(_callerRealm_, _result_.[[Value]]).
 			1. Else,
 				1. Throw a *TypeError* exception.
 		</emu-alg>
@@ -179,7 +179,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Suspend _evalContext_ and remove it from the execution context stack.
 				1. Resume the context that is now on the top of the execution context stack as the running execution context.
 				1. If _result_.[[Type]] is not ~normal~, throw a *TypeError* exception.
-				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
+				1. Return ? GetTransferrableValue(_callerRealm_, _result_.[[Value]]).
 			</emu-alg>
 			<emu-note type=editor>
 				In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected. There should be no ~return~ completion because this is a top level script evaluation, in which case a return |Statement| must result in a parsing error.
@@ -224,12 +224,12 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. If _hasOwn_ is *false*, throw a *TypeError* exception.
 				1. Let _value_ be ? Get(_exports_, _string_).
 				1. Let _realm_ be _f_.[[Realm]].
-				1. Return ? GetWrappedValue(_realm_, _value_).
+				1. Return ? GetTransferrableValue(_realm_, _value_).
 			</emu-alg>
 		</emu-clause>
 
-		<emu-clause id="sec-getwrappedvalue" aoid="GetWrappedValue">
-			<h1>GetWrappedValue ( _receiverRealm_, _value_ )</h1>
+		<emu-clause id="sec-gettransferrablevalue" aoid="GetTransferrableValue">
+			<h1>GetTransferrableValue ( _receiverRealm_, _value_ )</h1>
 			<emu-alg>
 				1. Assert: _receiverRealm_ is a Realm Record.
 				1. If Type(_value_) is Object, then

--- a/spec.html
+++ b/spec.html
@@ -229,14 +229,14 @@ location: https://tc39.es/proposal-shadowrealm/
 		</emu-clause>
 
 		<emu-clause id="sec-getwrappedvalue" aoid="GetWrappedValue">
-			<h1>GetWrappedValue ( _callerRealm_, _value_ )</h1>
+			<h1>GetWrappedValue ( _receiverRealm_, _value_ )</h1>
 			<emu-alg>
-				1. Assert: _callerRealm_ is a Realm Record.
+				1. Assert: _receiverRealm_ is a Realm Record.
 				1. If Type(_value_) is Object, then
 					1. If IsCallable(_value_) is *true*,
-						1. Return ! WrappedFunctionCreate(_callerRealm_, _value_).
+						1. Return ! WrappedFunctionCreate(_receiverRealm_, _value_).
 					1. If _value_ has an [[ArrayBufferData]] internal slot, then
-						1. If IsSharedArrayBuffer(_value_) if *true*, return ? CloneSharedArrayBuffer(_value_, _callerRealm_.[[Intrinsics]].%SharedArrayBuffer%).
+						1. If IsSharedArrayBuffer(_value_) if *true*, return ? CloneSharedArrayBuffer(_value_, _receiverRealm_.[[Intrinsics]].%SharedArrayBuffer%).
 					1. throw a TypeError exception.
 				1. Return _value_.
 			</emu-alg>

--- a/spec.html
+++ b/spec.html
@@ -233,10 +233,25 @@ location: https://tc39.es/proposal-shadowrealm/
 			<emu-alg>
 				1. Assert: _callerRealm_ is a Realm Record.
 				1. If Type(_value_) is Object, then
-				  1. If IsCallable(_value_) is *false*, throw a TypeError exception.
-				  1. Return ! WrappedFunctionCreate(_callerRealm_, _value_).
+					1. If IsCallable(_value_) is *true*,
+						1. Return ! WrappedFunctionCreate(_callerRealm_, _value_).
+					1. If _value_ has an [[ArrayBufferData]] internal slot, then
+						1. If IsSharedArrayBuffer(_value_) if *true*, return ? CloneSharedArrayBuffer(_value_, _callerRealm_.[[Intrinsics]].%SharedArrayBuffer%).
+					1. throw a TypeError exception.
 				1. Return _value_.
 			</emu-alg>
+		</emu-clause>
+
+		<emu-clause id="sec-clonesharedarraybuffer" aoid="CloneSharedArrayBuffer">
+			<h1>CloneSharedArrayBuffer ( _buffer_, _constructor_ )</h1>
+			<emu-alg>
+				1. Assert: _buffer_ is an Object with a [[SharedArrayBuffer]] internal.
+				1. Let _clone_ be ? OrdinaryCreateFromConstructor(_constructor_, "%SharedArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]] »).
+				1. Assert: _value_ and _clone_ are instances of SharedArrayBuffer of different Realms each.
+				1. Set _clone_.[[ArrayBufferData]] to _value_.[[ArrayBufferData]].
+				1. Set _clone_.[[ArrayBufferByteLength]] to _value_.[[ArrayBufferByteLength]].
+				1. Return _clone_.
+			</emu-alg>>
 		</emu-clause>
 
 		<emu-clause id="sec-validateshadowrealmobject" aoid="ValidateShadowRealmObject">

--- a/spec.html
+++ b/spec.html
@@ -236,22 +236,15 @@ location: https://tc39.es/proposal-shadowrealm/
 					1. If IsCallable(_value_) is *true*,
 						1. Return ! WrappedFunctionCreate(_receiverRealm_, _value_).
 					1. If _value_ has an [[ArrayBufferData]] internal slot, then
-						1. If IsSharedArrayBuffer(_value_) if *true*, return ? CloneSharedArrayBuffer(_value_, _receiverRealm_.[[Intrinsics]].%SharedArrayBuffer%).
-					1. throw a TypeError exception.
+						1. If IsSharedArrayBuffer(_value_) is *true*, then
+							1. Let _clone_ be ! OrdinaryObjectCreate(_receiverRealm_.[[Intrinsics]].%SharedArrayBuffer.prototype%, « [[ArrayBufferData]], [[ArrayBufferByteLength]] »).
+							1. Assert: _value_ and _clone_ are instances of SharedArrayBuffer of different Realms each.
+							1. Set _clone_.[[ArrayBufferData]] to _value_.[[ArrayBufferData]].
+							1. Set _clone_.[[ArrayBufferByteLength]] to _value_.[[ArrayBufferByteLength]].
+							1. Return _clone_.
+					1. Throw a TypeError exception.
 				1. Return _value_.
 			</emu-alg>
-		</emu-clause>
-
-		<emu-clause id="sec-clonesharedarraybuffer" aoid="CloneSharedArrayBuffer">
-			<h1>CloneSharedArrayBuffer ( _buffer_, _constructor_ )</h1>
-			<emu-alg>
-				1. Assert: _buffer_ is an Object with a [[SharedArrayBuffer]] internal.
-				1. Let _clone_ be ? OrdinaryCreateFromConstructor(_constructor_, "%SharedArrayBuffer.prototype%", « [[ArrayBufferData]], [[ArrayBufferByteLength]] »).
-				1. Assert: _value_ and _clone_ are instances of SharedArrayBuffer of different Realms each.
-				1. Set _clone_.[[ArrayBufferData]] to _value_.[[ArrayBufferData]].
-				1. Set _clone_.[[ArrayBufferByteLength]] to _value_.[[ArrayBufferByteLength]].
-				1. Return _clone_.
-			</emu-alg>>
 		</emu-clause>
 
 		<emu-clause id="sec-validateshadowrealmobject" aoid="ValidateShadowRealmObject">


### PR DESCRIPTION
This PR is to explore the possibility of allowing SharedArrayBuffers to be transferred cross shadow realms as discussed internally by @rwaldron and @caridy. They might expand the use cases and we also have #298 and #322.

The feature only accounts for the buffer data and size, reusing the intrinsic SharedArrayBuffer. Object properties are not transferred here.

This code example quickly shows up it is expected to work:

```js
const r = new ShadowRealm();
const sab = new SharedArrayBuffer(8);
const getFoo = r.evaluate('(clonedSab) => clonedSab.foo');

sab.foo = 2;

// The ShadowRealm creates a new SAB reusing the already allocated sharedarraybuffer data.
getFoo(sab); // undefined

const cloneBack = r.evaluate(`
  (clonedSab) => {
    clonedSab[0] = 1;
    return clonedSab;
  };
`);

const otherSab = cloneBack(sab);

otherSab === sab; // false;
sab[0]; // 1
otherSab[0]; // 1
```

This might be considered as ~~a Stage 3 change or~~ a follow up proposal.