### PR TITLE
Normative: Remove the name prefix for wrapped functions

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -150,7 +150,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Set _wrapped_.[[Call]] as described in <emu-xref href="#sec-wrapped-function-exotic-objects-call-thisargument-argumentslist"></emu-xref>.
 				1. Set _wrapped_.[[WrappedTargetFunction]] to _Target_.
 				1. Set _wrapped_.[[Realm]] to _callerRealm_.
-				1. Let _result_ be CopyNameAndLength(_wrapped_, _Target_, *"wrapped"*).
+				1. Let _result_ be CopyNameAndLength(_wrapped_, _Target_).
 				1. If _result_ is an Abrupt Completion, throw a TypeError exception.
 				1. Return _wrapped_.
 			</emu-alg>
@@ -161,7 +161,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				CopyNameAndLength (
 					_F_: a function object,
 					_Target_: a function object,
-					_prefix_: a String,
+					optional _prefix_: a String,
 					optional _argCount_: a Number,
 				)
 			</h1>


### PR DESCRIPTION
We got the consensus reported in https://github.com/tc39/proposal-shadowrealm/issues/338#issuecomment-994000234 with the following information:

> - length is set similarly to bound functions.
> - Copy the name from the target function, no prefix. Restricted to string-only values, similarly to bound functions.

This PR address the second bullet.

Although, some confusion came in from noted conclusion/resolution from the [meeting in Dec 2021](https://github.com/tc39/notes/blob/master/meetings/2021-12/dec-14.md#conclusionresolution-3). 

> - wrapped functions to use the target function's name/length as in https://github.com/tc39/proposal-shadowrealm/pull/339
> - future exploration of sharing SABs to continue 

Where #339 still had the prefix and was merged as is.

I did not attend that meeting but did work on the slides and sync'ed with @rwaldron before it. I remember that we would request the consensus for the no-prefix option and it looks like what it was agreed upon reading the notes (not only the conclusion part).

> RW: So here is the question of the day that we do need an answer about: How should wrapped functions use target function’s name and length. Note that this is definitely a normative change, in that it is a spec fix where there is no spec now. What we propose is that the length gets set similarly to bound functions and that the name is copied from the target function, but not with any prefix, and is restricted to string values only. This is similar to bound functions, but without a prefix. The pull request #338 has the change in it. Hopefully folks have had a chance to take a peek at that. If you haven't I would love it if you did.
> 
> RW: Can we get consensus on the way we’d like to solve this? Are there any questions the I can answer?
> 
> RPR: No one is on the queue at the moment.
> 
> - normative change
>
> RW: neat. So I'll ask for consensus
> 
> MAH: +1
> 
> YSV: Yeah, I support this also.
> 
> RW: Great. Thanks folks. Getting it done.

Thanks @caitp for pointing out we had the prefix in the main branch.

---

So I believe this PR is still a "has consensus" change, but it's alright if someone thinks it's good to present it again at the plenary.

cc @caitp @legendecas @syg @codehag @phoddie. 