### PR TITLE
Fixes #353: Normative changes for `Error.message`

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -141,7 +141,10 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<emu-note>
-			For implementations that provide implementation-specific stack for introspection APIs, the TypeError object can be augmented without revealing any information about the stack from within the ShadowRealm, and without providing direct access to any object reference from withtin the ShadowRealm.
+			Host environments may provide implementation-specific stack information for introspection APIs, if so, the _newError_ object can be augmented without providing direct access to any object reference from _originalError_ or its associated Realm. The specific steps are implementation-defined.
+		</emu-note>
+		<emu-note type="editor">
+			For implementations can store all the information needed to create the full stack in a way that can be used by CreateTypeErrorCopy abstract operation to stitch together a censored version of the stack for _newError_ if _realmRecord_ is associated to a ShadowRealm instance. If the information exposed as part of _newError_'s stack must be censored, it must contain only the inclusion of the stack-frames associated to _realmRecord_.
 		</emu-note>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -138,7 +138,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<p>
-			Host environments may provide implementation-specific message value and stack information for introspection APIs. The implementation may store additional information on _originalError_ to produce the _newError_'s message and stack information on _newError_ to prevent CreateTypeErrorCopy to be observed from ECMAScript code. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
+			Host environments may provide implementation-specific message value and stack information for introspection APIs. CreateTypeErrorCopy abstract operation must not cause any ECMAScript code execution. The implementation may store additional information on _originalError_ to produce the _newError_'s message and stack information. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
 		</p>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -138,7 +138,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<p>
-			Host environments may provide implementation-specific message value and stack information for introspection APIs. The implementation may use information it has stored on _originalError_ to produce the _newError_'s message and stack information on _newError_. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
+			Host environments may provide implementation-specific message value and stack information for introspection APIs. The implementation may  store additional information on _originalError_ to produce the _newError_'s message and stack information on _newError_ to prevent CreateTypeErrorCopy to be observed from ECMAScript code. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
 		</p>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -120,9 +120,9 @@ location: https://tc39.es/proposal-shadowrealm/
 		<emu-note type=editor>
 			In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected.
 		</emu-note>
-		<emu-note>
+		<p>
 			Host environments may provide implementation-specific stack information for introspection APIs. If so, all Error objects originating from code executed inside a ShadowRealm must be subject to censorship. The specific steps are implementation-defined but must respect the following: The information exposed as part of Error's stack must contain only the details of the stack-frames associated to the ShadowRealm, and not reveal any details of frames associated with other realms, including the number of any such frames. Implementations can store information of the full stack if the error can cross into another Realm, however the implementation cannot use that information to reveal more information than allowed above.
-		</emu-note>
+		</p>
 	</emu-clause>
 
 	<emu-clause id="sec-create-type-error-copy" type="abstract operation">
@@ -143,9 +143,9 @@ location: https://tc39.es/proposal-shadowrealm/
 						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "message", _message_).
 			1. Return _newError_.
 		</emu-alg>
-		<emu-note>
+		<p>
 			Host environments may provide implementation-specific stack information for introspection APIs. The implementation may augment the exposed stack information of _newError_ with information it has stored on _originalError_. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
-		</emu-note>
+		</p>
 	</emu-clause>
 
 	<emu-clause id="sec-ordinary-wrapped-function-call" type="abstract operation">

--- a/spec.html
+++ b/spec.html
@@ -120,6 +120,9 @@ location: https://tc39.es/proposal-shadowrealm/
 		<emu-note type=editor>
 			In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected.
 		</emu-note>
+		<emu-note>
+			Host environments may provide implementation-specific stack information for introspection APIs. If so, all Error objects originating from code executed inside a ShadowRealm must be subject to censorship. The specific steps are implementation-defined but must respect the following: The information exposed as part of Error's stack must contain only the details of the stack-frames associated to the ShadowRealm, and not reveal any details of frames associated with other realms, including the number of any such frames. Implementations can store information of the full stack if the error can cross into another Realm, however the implementation cannot use that information to reveal more information than allowed above.
+		</emu-note>
 	</emu-clause>
 
 	<emu-clause id="sec-create-type-error-copy" type="abstract operation">
@@ -141,10 +144,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<emu-note>
-			Host environments may provide implementation-specific stack information for introspection APIs, if so, the _newError_ object can be augmented without providing direct access to any object reference from _originalError_ or its associated Realm. The specific steps are implementation-defined.
-		</emu-note>
-		<emu-note type="editor">
-			For implementations can store all the information needed to create the full stack in a way that can be used by CreateTypeErrorCopy abstract operation to stitch together a censored version of the stack for _newError_ if _realmRecord_ is associated to a ShadowRealm instance. If the information exposed as part of _newError_'s stack must be censored, it must contain only the inclusion of the stack-frames associated to _realmRecord_.
+			Host environments may provide implementation-specific stack information for introspection APIs. The implementation may augment the exposed stack information of _newError_ with information it has stored on _originalError_. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
 		</emu-note>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -141,7 +141,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<emu-note>
-			For implementations that provide implementation-specific stack for introspection APIs, the TypeError object can be augmented without releaving any information about the stack from within the ShadowRealm, and without providing direct access to any object reference from withtin the ShadowRealm.
+			For implementations that provide implementation-specific stack for introspection APIs, the TypeError object can be augmented without revealing any information about the stack from within the ShadowRealm, and without providing direct access to any object reference from withtin the ShadowRealm.
 		</emu-note>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -135,16 +135,10 @@ location: https://tc39.es/proposal-shadowrealm/
 		<emu-alg>
 			1. Let _newError_ be a newly created *TypeError* object.
 			1. NOTE: _newError_ is created in _realmRecord_.
-			1. If Type(_originalError_) is Object, then
-				1. Let _message_ be Completion(Get(_originalError_, "message")).
-				1. If _message_ is not an abrupt completion, then
-					1. If Type(_message_) is String, then
-						1. NOTE: Copying the string message when possible.
-						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "message", _message_).
 			1. Return _newError_.
 		</emu-alg>
 		<p>
-			Host environments may provide implementation-specific stack information for introspection APIs. The implementation may augment the exposed stack information of _newError_ with information it has stored on _originalError_. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
+			Host environments may provide implementation-specific message value and stack information for introspection APIs. The implementation may use information it has stored on _originalError_ to produce the _newError_'s message and stack information on _newError_. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
 		</p>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -122,6 +122,32 @@ location: https://tc39.es/proposal-shadowrealm/
 		</emu-note>
 	</emu-clause>
 
+	<emu-clause id="sec-create-type-error-copy" type="abstract operation">
+		<h1>
+			CreateTypeErrorCopy (
+				_realmRecord_: a Realm Record,
+				_originalError_: an ECMAScript language value
+			)
+		</h1>
+		<emu-alg>
+			1. Let _newError_ be a newly created *TypeError* object.
+			1. NOTE: _newError_ is created in _realmRecord_.
+			1. If Type(_originalError_) is Object, then
+				1. Let _message_ be Completion(Get(_originalError_, "message")).
+				1. If _message_ is not an abrupt completion, then
+					1. Let _msgString_ be Completion(ToString(_message_)).
+					1. If _msgString_ is not an abrupt completion, then
+						1. NOTE: Copying the string message when possible.
+						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "message", _msgString_).
+				1. Let _cause_ be Completion(Get(_originalError_, "cause")).
+				1. If _cause_ is not an abrupt completion, then
+					1. If Type(_cause_) is String, then
+						1. NOTE: Copying the cause if it a string.
+						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "cause", _cause_).
+			1. Return _newError_.
+		</emu-alg>
+	</emu-clause>
+
 	<emu-clause id="sec-ordinary-wrapped-function-call" type="abstract operation">
 		<h1>
 			OrdinaryWrappedFunctionCall (
@@ -145,7 +171,8 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. If _result_.[[Type]] is ~normal~ or _result_.[[Type]] is ~return~, then
 				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
 			1. Else,
-				1. Throw a *TypeError* exception.
+				1. Let _copiedError_ be ! CreateTypeErrorCopy(_callerRealm_, _result_.[[Value]]).
+				1. Return ThrowCompletion(_copiedError_).
 		</emu-alg>
 	</emu-clause>
 
@@ -296,7 +323,9 @@ location: https://tc39.es/proposal-shadowrealm/
 					1. Set result to NormalCompletion(*undefined*).
 				1. Suspend _evalContext_ and remove it from the execution context stack.
 				1. Resume the context that is now on the top of the execution context stack as the running execution context.
-				1. If _result_.[[Type]] is not ~normal~, throw a *TypeError* exception.
+				1. If _result_.[[Type]] is not ~normal~, then
+					1. Let _copiedError_ be ! CreateTypeErrorCopy(_callerRealm_, _result_.[[Value]]).
+					1. Return ThrowCompletion(_copiedError_).
 				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
 			</emu-alg>
 			<emu-note type=editor>
@@ -332,8 +361,10 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Let _steps_ be the steps of an ExportGetter function as described below.
 				1. Let _onFulfilled_ be CreateBuiltinFunction(_steps_, 1, *""*, « [[ExportNameString]] », _callerRealm_).
 				1. Set _onFulfilled_.[[ExportNameString]] to _exportNameString_.
+				1. Let _errorSteps_ be the steps of an ImportValueError function as described below.
+				1. Let _onRejected_ be CreateBuiltinFunction(_errorSteps_, 1, *""*, «», _callerRealm_).
 				1. Let _promiseCapability_ be ! NewPromiseCapability(%Promise%).
-				1. Return PerformPromiseThen(_innerCapability_.[[Promise]], _onFulfilled_, _callerRealm_.[[Intrinsics]].[[%ThrowTypeError%]], _promiseCapability_).
+				1. Return PerformPromiseThen(_innerCapability_.[[Promise]], _onFulfilled_, _onRejected_, _promiseCapability_).
 			</emu-alg>
 
 			<p>An ExportGetter function is an anonymous built-in function with a [[ExportNameString]] internal slot. When an ExportGetter function is called with argument _exports_, it performs the following steps:</p>
@@ -347,6 +378,13 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Let _value_ be ? Get(_exports_, _string_).
 				1. Let _realm_ be _f_.[[Realm]].
 				1. Return ? GetWrappedValue(_realm_, _value_).
+			</emu-alg>
+
+			<p>An ImportValueError function is an anonymous built-in function. When an ImportValueError function is called with argument _error_, it performs the following steps:</p>
+			<emu-alg>
+				1. Let _realmRecord_ be the function's associated Realm Record.
+				1. Let _copiedError_ be ! CreateTypeErrorCopy(_realmRecord_, _error_).
+				1. Return ThrowCompletion(_copiedError_).
 			</emu-alg>
 		</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -127,7 +127,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			CreateTypeErrorCopy (
 				_realmRecord_: a Realm Record,
 				_originalError_: an ECMAScript language value
-			)
+			): A TypeError object
 		</h1>
 		<emu-alg>
 			1. Let _newError_ be a newly created *TypeError* object.
@@ -141,7 +141,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<emu-note>
-			For implementations that provide implementation-specific stack for introspection APIs, the TypeError object can be augmented.
+			For implementations that provide implementation-specific stack for introspection APIs, the TypeError object can be augmented without releaving any information about the stack from within the ShadowRealm, and without providing direct access to any object reference from withtin the ShadowRealm.
 		</emu-note>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -168,7 +168,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. If _result_.[[Type]] is ~normal~ or _result_.[[Type]] is ~return~, then
 				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
 			1. Else,
-				1. Let _copiedError_ be ! CreateTypeErrorCopy(_callerRealm_, _result_.[[Value]]).
+				1. Let _copiedError_ be CreateTypeErrorCopy(_callerRealm_, _result_.[[Value]]).
 				1. Return ThrowCompletion(_copiedError_).
 		</emu-alg>
 	</emu-clause>
@@ -321,7 +321,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				1. Suspend _evalContext_ and remove it from the execution context stack.
 				1. Resume the context that is now on the top of the execution context stack as the running execution context.
 				1. If _result_.[[Type]] is not ~normal~, then
-					1. Let _copiedError_ be ! CreateTypeErrorCopy(_callerRealm_, _result_.[[Value]]).
+					1. Let _copiedError_ be CreateTypeErrorCopy(_callerRealm_, _result_.[[Value]]).
 					1. Return ThrowCompletion(_copiedError_).
 				1. Return ? GetWrappedValue(_callerRealm_, _result_.[[Value]]).
 			</emu-alg>
@@ -380,7 +380,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			<p>An ImportValueError function is an anonymous built-in function. When an ImportValueError function is called with argument _error_, it performs the following steps:</p>
 			<emu-alg>
 				1. Let _realmRecord_ be the function's associated Realm Record.
-				1. Let _copiedError_ be ! CreateTypeErrorCopy(_realmRecord_, _error_).
+				1. Let _copiedError_ be CreateTypeErrorCopy(_realmRecord_, _error_).
 				1. Return ThrowCompletion(_copiedError_).
 			</emu-alg>
 		</emu-clause>

--- a/spec.html
+++ b/spec.html
@@ -120,9 +120,6 @@ location: https://tc39.es/proposal-shadowrealm/
 		<emu-note type=editor>
 			In the case of an abrupt ~throw~ completion, the type of error to be created should match the type of the abrupt throw completion record. This could be revisited when merging into the main specification. Additionally, in the case of a ~break~ or ~continue~ completion, since those are not supported, a TypeError is expected.
 		</emu-note>
-		<p>
-			Host environments may provide implementation-specific stack information for introspection APIs. If so, all Error objects originating from code executed inside a ShadowRealm must be subject to censorship. The specific steps are implementation-defined but must respect the following: The information exposed as part of Error's stack must contain only the details of the stack-frames associated to the ShadowRealm, and not reveal any details of frames associated with other realms, including the number of any such frames. Implementations can store information of the full stack if the error can cross into another Realm, however the implementation cannot use that information to reveal more information than allowed above.
-		</p>
 	</emu-clause>
 
 	<emu-clause id="sec-create-type-error-copy" type="abstract operation">
@@ -138,7 +135,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<p>
-			Host environments may provide implementation-specific message value and stack information for introspection APIs. CreateTypeErrorCopy abstract operation must not cause any ECMAScript code execution. The implementation may store additional information on _originalError_ to produce the _newError_'s message and stack information. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
+			Host environments may provide implementation-specific message value. CreateTypeErrorCopy abstract operation must not cause any ECMAScript code execution. The implementation may store additional information on _originalError_ to produce the _newError_'s message.
 		</p>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -138,7 +138,7 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. Return _newError_.
 		</emu-alg>
 		<p>
-			Host environments may provide implementation-specific message value and stack information for introspection APIs. The implementation may  store additional information on _originalError_ to produce the _newError_'s message and stack information on _newError_ to prevent CreateTypeErrorCopy to be observed from ECMAScript code. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
+			Host environments may provide implementation-specific message value and stack information for introspection APIs. The implementation may store additional information on _originalError_ to produce the _newError_'s message and stack information on _newError_ to prevent CreateTypeErrorCopy to be observed from ECMAScript code. If _realmRecord_ corresponds to a ShadowRealm, _newError_ object must be subject to censorship in the same way Errors originated from _realmRecord_ are censored. Regardless of the _realmRecord_, the implementation must not include object references to _originalError_ or its associated realm in the stack information exposed to the program.
 		</p>
 	</emu-clause>
 

--- a/spec.html
+++ b/spec.html
@@ -135,17 +135,14 @@ location: https://tc39.es/proposal-shadowrealm/
 			1. If Type(_originalError_) is Object, then
 				1. Let _message_ be Completion(Get(_originalError_, "message")).
 				1. If _message_ is not an abrupt completion, then
-					1. Let _msgString_ be Completion(ToString(_message_)).
-					1. If _msgString_ is not an abrupt completion, then
+					1. If Type(_message_) is String, then
 						1. NOTE: Copying the string message when possible.
-						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "message", _msgString_).
-				1. Let _cause_ be Completion(Get(_originalError_, "cause")).
-				1. If _cause_ is not an abrupt completion, then
-					1. If Type(_cause_) is String, then
-						1. NOTE: Copying the cause if it a string.
-						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "cause", _cause_).
+						1. Perform CreateNonEnumerableDataPropertyOrThrow(_newError_, "message", _message_).
 			1. Return _newError_.
 		</emu-alg>
+		<emu-note>
+			For implementations that provide implementation-specific stack for introspection APIs, the TypeError object can be augmented.
+		</emu-note>
 	</emu-clause>
 
 	<emu-clause id="sec-ordinary-wrapped-function-call" type="abstract operation">


### PR DESCRIPTION
## This PR introduces 1 normative change:

 * [x] CreateTypeErrorCopy abstract operation must not cause any ECMAScript code execution when creating a new message.

Refactor PR to make it simpler to recognize when an error must be copied over the callable boundary into the caller realm, whether that's a result of `evaluation`, `importValue` or just calling a wrapped function.

This PR is the result of the achieved consensus during the Dic 1st, 2022 Plenary discussion.