### PR TITLE
Editorial: Fix ecmarkup typecheck errors

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -128,6 +128,8 @@ location: https://tc39.es/proposal-shadowrealm/
 				_originalError_: an ECMAScript language value
 			): A TypeError object
 		</h1>
+		<dl class="header">
+		</dl>
 		<emu-alg>
 			1. Let _newError_ be a newly created *TypeError* object.
 			1. NOTE: _newError_ is created in _realmRecord_.


### PR DESCRIPTION
See https://github.com/tc39/proposal-shadowrealm/actions/runs/4012414741/jobs/6890837736. The latest spec (https://github.com/tc39/proposal-shadowrealm/pull/382) is not deployed due to build failures.