### PR TITLE
Editorial: Use consistent Well-Known capitalization as ECMAScript Spec

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -15,8 +15,8 @@ location: https://tc39.es/proposal-shadowrealm/
 </pre>
 
 <emu-clause id="sec-well-known-intrinsic-objects">
-	<h1>Well-known intrinsic objects</h1>
-	<emu-table id="table-7" caption="Well-known Intrinsic Objects">
+	<h1>Well-Known intrinsic objects</h1>
+	<emu-table id="table-7" caption="Well-Known Intrinsic Objects">
 		<table>
 			<tbody>
 				<tr>


### PR DESCRIPTION
ECMAScript spec used "Well-Known" as capitalization in the header and caption.

https://tc39.es/ecma262/#sec-well-known-intrinsic-objects