### PR TITLE
Editorial: Adapt to new HostEnsureCanCompileStrings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "watch": "npm run build -- --watch"
   },
   "devDependencies": {
-    "@tc39/ecma262-biblio": "=2.1.2639",
+    "@tc39/ecma262-biblio": "=2.1.2687",
     "ecmarkup": "^18.0.0"
   }
 }

--- a/spec.html
+++ b/spec.html
@@ -311,7 +311,7 @@ location: https://tc39.es/proposal-shadowrealm/
 				<dd>...</dd>
 			</dl>
 			<emu-alg>
-				1. Perform ? HostEnsureCanCompileStrings(_evalRealm_).
+				1. Perform ? HostEnsureCanCompileStrings(_evalRealm_, « », _sourceText_, *false*).
 				1. Perform the following substeps in an implementation-defined order, possibly interleaving parsing and error detection:
 					1. Let _script_ be ParseText(StringToCodePoints(_sourceText_), |Script|).
 					1. If _script_ is a List of errors, throw a *SyntaxError* exception.


### PR DESCRIPTION
As of https://github.com/tc39/ecma262/pull/3222 the signature of HostEnsureCanCompileStrings changed. This adapts to the new signature by pulling in the latest version of ecma262-biblio and adding the missing arguments.

Closes: #367