### PR TITLE
Remove console from list of examples

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -611,7 +611,7 @@ location: https://tc39.es/proposal-shadowrealm/
 					interfaces are included. The Web Platform and Web-like
 					environments may decide to include `EventTarget`,
 					`atob`, `TextEncoder`, `URL`, etc. while at the same time not
-					including `HTMLElement`, `console`, `localStorage`, `fetch`, etc.
+					including `HTMLElement`, `localStorage`, `fetch`, etc.
 				</p>
 			</emu-note>
 			<emu-note type=editor>


### PR DESCRIPTION
This is just a hypothetical example, so it has no weight in what actually gets exposed, but since we do actually want console to be exposed let's remove console from the list of examples.

h/t @lukewarlow